### PR TITLE
Improved networking and file uploads referencing issue #6

### DIFF
--- a/viur_admin/actions/file.py
+++ b/viur_admin/actions/file.py
@@ -17,7 +17,9 @@ class FileUploadAction(QtWidgets.QAction):
 		self.setShortcutContext(QtCore.Qt.WidgetWithChildrenShortcut)
 
 	def onTriggered(self, e):
-		files, other = QtWidgets.QFileDialog.getOpenFileNames()
+		homeDirs = QtCore.QStandardPaths.standardLocations(QtCore.QStandardPaths.HomeLocation)
+		logger.debug("homeDirs: %r", homeDirs)
+		files, other = QtWidgets.QFileDialog.getOpenFileNames(directory=homeDirs[0])
 		print("file on triggered", files, repr(other))
 		self.parent().doUpload(files, self.parent().getNode())
 

--- a/viur_admin/actions/file.py
+++ b/viur_admin/actions/file.py
@@ -1,8 +1,11 @@
 # -*- coding: utf-8 -*-
 
 from PyQt5 import QtCore, QtGui, QtWidgets
+from viur_admin.log import getLogger
 
 from viur_admin.priorityqueue import actionDelegateSelector
+
+logger = getLogger(__name__)
 
 
 class FileUploadAction(QtWidgets.QAction):
@@ -15,8 +18,25 @@ class FileUploadAction(QtWidgets.QAction):
 
 	def onTriggered(self, e):
 		files, other = QtWidgets.QFileDialog.getOpenFileNames()
-		# print("file on triggered", files, repr(other))
+		print("file on triggered", files, repr(other))
 		self.parent().doUpload(files, self.parent().getNode())
+
+		# TODO: all this shit would be needed for being able to select both dirs and files, but it's also buggy.
+		# TODO: if you go down into a directory hierarchy, all directories on the path and the files get selected. SO SAD!
+		# dlg = QtWidgets.QFileDialog()
+		# dlg.setFileMode(QtWidgets.QFileDialog.Directory)
+		# dlg.setOption(QtWidgets.QFileDialog.DontUseNativeDialog, True)
+		# listView = dlg.findChild(QtWidgets.QListView, "listView")
+		# if listView:
+		# 	listView.setSelectionMode(QtWidgets.QAbstractItemView.MultiSelection)
+		# treeView = dlg.findChild(QtWidgets.QTreeView)
+		# if treeView:
+		# 	treeView.setSelectionMode(QtWidgets.QAbstractItemView.MultiSelection)
+		# status = dlg.exec()
+		# if status:
+		# 	files = dlg.selectedFiles()
+		# 	logger.debug("FileUploadAction upload instance: %r", self.parent())
+		# 	self.parent().doUpload(files, self.parent().getNode())
 
 	@staticmethod
 	def isSuitableFor(modul, actionName):

--- a/viur_admin/network.py
+++ b/viur_admin/network.py
@@ -523,7 +523,7 @@ class NetworkService():
 				filePart = QHttpPart()
 				filePart.setHeader(QNetworkRequest.ContentTypeHeader, mimetype)
 				filePart.setHeader(QNetworkRequest.ContentDispositionHeader,
-				                   'form-data; name="{0}"; filename="{1}"'.format(key, value.fileName()))
+				                   'form-data; name="{0}"; filename="{1}"'.format(key, os.path.basename(value.fileName())))
 				filePart.setBodyDevice(value)
 				value.setParent(multiPart)
 				multiPart.append(filePart)

--- a/viur_admin/network.py
+++ b/viur_admin/network.py
@@ -20,11 +20,14 @@ from PyQt5 import QtCore, QtWidgets
 import sys
 import time
 from viur_admin.config import conf
-from PyQt5.QtCore import QUrl, QObject
-from PyQt5.QtNetwork import QNetworkAccessManager, QNetworkRequest, QSslConfiguration, QSslCertificate, QNetworkReply, QNetworkCookieJar
+from PyQt5.QtCore import QUrl, QObject, QVariant
+from PyQt5.QtNetwork import QNetworkAccessManager, QNetworkRequest, QSslConfiguration, QSslCertificate, QNetworkReply, \
+	QNetworkCookieJar, QHttpPart, QHttpMultiPart
 from urllib import request
 
 import viur_admin.ui.icons_rc
+
+viur_admin.ui.icons_rc  ## import guard
 
 ##Setup the SSL-Configuration. We accept only the two known Certificates from google; reject all other
 try:
@@ -62,8 +65,8 @@ class MyCookieJar(QNetworkCookieJar):
 
 	pass
 
-nam.setCookieJar(MyCookieJar())
 
+nam.setCookieJar(MyCookieJar())
 
 mimetypes.init()
 if os.path.exists("mime.types"):
@@ -153,7 +156,8 @@ class SecurityTokenProvider(QObject):
 		# self.logger.warning("Error fetching skey: %r", error)
 		SecurityTokenProvider.errorCount += 1
 		self.isRequesting = False
-		raise ValueError("onError")
+
+	# raise ValueError("onError")
 
 	def onSkeyAvailable(self, request=None):
 		"""
@@ -177,7 +181,8 @@ class SecurityTokenProvider(QObject):
 			self.queue.put((skey, time.time()), False)
 		except QFull:
 			pass
-			# print("Err: Queue FULL")
+
+	# print("Err: Queue FULL")
 
 	def getKey(self):
 		"""
@@ -194,9 +199,11 @@ class SecurityTokenProvider(QObject):
 					# self.logger.debug("Discarding old skey")
 					skey = None
 					raise QEmpty()
-			except QEmpty:
-				# self.logger.debug("Empty cache! Please wait...")
+			except QEmpty as err:
+				logger.debug("Empty cache! Please wait...")
 				QtCore.QCoreApplication.processEvents()
+			except ValueError as err:
+				logger.exception(err)
 		# self.logger.debug("Using skey: %s", skey)
 		return (skey)
 
@@ -236,18 +243,24 @@ class RequestWrapper(QtCore.QObject):
 		request.downloadProgress.connect(self.onDownloadProgress)
 		request.uploadProgress.connect(self.onUploadProgress)
 		request.finished.connect(self.onFinished)
+		logger.debug("RequestWrapper exit")
 
 	def onDownloadProgress(self, bytesReceived, bytesTotal):
+		logger.debug("onDownloadProgress")
 		if bytesReceived == bytesTotal:
 			self.requestStatus = True
 		self.downloadProgress.emit(self, bytesReceived, bytesTotal)
+		logger.debug("onDownloadProgress done")
 
 	def onUploadProgress(self, bytesSend, bytesTotal):
+		logger.debug("onUploadProgress")
 		if bytesSend == bytesTotal:
 			self.requestStatus = True
 		self.uploadProgress.emit(self, bytesSend, bytesTotal)
+		logger.debug("onUploadProgress done")
 
 	def onFinished(self):
+		logger.debug("onFinished")
 		self.hasFinished = True
 		if self.request.error() == self.request.NoError:
 			self.requestSucceeded.emit(self)
@@ -269,11 +282,14 @@ class RequestWrapper(QtCore.QObject):
 		self.failureHandler = None
 		self.finishedHandler = None
 		self.deleteLater()
+		logger.debug("onFinished exit")
 
 	def readAll(self):
-		return (self.request.readAll())
+		logger.debug("readAll")
+		return self.request.readAll()
 
 	def abort(self):
+		logger.debug("abort")
 		self.request.abort()
 
 
@@ -338,13 +354,12 @@ class RequestGroup(QtCore.QObject):
 		req = NetworkService.request(*args, parent=self, **kwargs)
 		self.addQuery(req)
 
-
-
 	def onProgress(self, request, bytesReceived, bytesTotal):
 		if bytesReceived == bytesTotal:
 			self.progessUpdate.emit(self, self.maxQueryCount - self.queryCount, self.maxQueryCount)
-		# self.emit( QtCore.SIGNAL("progessUpdate(PyQt_PyObject,PyQt_PyObject,PyQt_PyObject)"), self,
-		# self.maxQueryCount-len( self.querys ), self.maxQueryCount )
+
+	# self.emit( QtCore.SIGNAL("progessUpdate(PyQt_PyObject,PyQt_PyObject,PyQt_PyObject)"), self,
+	# self.maxQueryCount-len( self.querys ), self.maxQueryCount )
 
 	def onError(self, request, error):
 		self.requestFailed.emit(self)
@@ -429,7 +444,7 @@ class RemoteFile(QtCore.QObject):
 
 	def onTimerEvent(self):
 		# self.logger.debug("Checkpoint: onTimerEvent")
-		
+
 		if "successHandlerSelf" in dir(self):
 			s = self.successHandlerSelf()
 			if s:
@@ -464,7 +479,7 @@ class RemoteFile(QtCore.QObject):
 				getattr(s, self.successHandlerName)(self)
 			except Exception as err:
 				pass
-				# self.logger.exception(err)
+		# self.logger.exception(err)
 		self._delayTimer = QtCore.QTimer(self)
 		# Queue our deletion giving our child (networkReply) chance to finish
 		self._delayTimer.singleShot(250, self.remove)
@@ -495,6 +510,44 @@ class NetworkService():
 
 	@staticmethod
 	def genReqStr(params):
+		multiPart = QHttpMultiPart(QHttpMultiPart.FormDataType)
+		for key, value in params.items():
+			logger.debug("key, value: %r, %r", key, value)
+			if isinstance(value, QtCore.QFile):  # file content must be a QFile object
+				try:
+					(mimetype, encoding) = mimetypes.guess_type(value.fileName(), strict=False)
+					logger.debug("guessing mimetype: %r, %r", mimetype, encoding)
+					mimetype = mimetype or "application/octet-stream"
+				except:
+					mimetype = "application/octet-stream"
+				filePart = QHttpPart()
+				filePart.setHeader(QNetworkRequest.ContentTypeHeader, mimetype)
+				filePart.setHeader(QNetworkRequest.ContentDispositionHeader,
+				                   'form-data; name="{0}"; filename="{1}"'.format(key, value.fileName()))
+				filePart.setBodyDevice(value)
+				value.setParent(multiPart)
+				multiPart.append(filePart)
+				logger.debug("file part: %r", filePart)
+			elif isinstance(value, list):
+				for val in value:
+					textPart = QHttpPart()
+					textPart.setHeader(QNetworkRequest.ContentTypeHeader, QVariant(b"application/octet-stream"))
+					textPart.setHeader(QNetworkRequest.ContentDispositionHeader,
+					                   'form-data; name="{0}"'.format(key.encode("utf-8")))
+					textPart.setBody(str(val).encode("utf-8"))
+					multiPart.append(textPart)
+					logger.debug("list part: %r", textPart)
+			else:
+				otherPart = QHttpPart()
+				otherPart.setHeader(QNetworkRequest.ContentTypeHeader, "application/octet-stream")
+				otherPart.setHeader(QNetworkRequest.ContentDispositionHeader, 'form-data; name="{0}"'.format(key))
+				otherPart.setBody(str(value).encode("utf-8"))
+				multiPart.append(otherPart)
+				logger.debug("other part: %r", otherPart)
+		return multiPart
+
+	@staticmethod
+	def genReqStr_old(params):
 		boundary_str = "---" + ''.join(
 			[random.choice(string.ascii_lowercase + string.ascii_uppercase + string.digits) for x in range(13)])
 		boundary = boundary_str.encode("UTF-8")
@@ -565,45 +618,59 @@ class NetworkService():
 			reqURL = QUrl(url)
 		else:
 			reqURL = QUrl(NetworkService.url + url)
+		logger.debug("preparing request: %r", reqURL)
 		req = QNetworkRequest(reqURL)
 		if extraHeaders:
 			for k, v in extraHeaders.items():
 				req.setRawHeader(k, v)
 		if params:
 			if isinstance(params, dict):
-				multipart, boundary = NetworkService.genReqStr(params)
-				req.setRawHeader(b"Content-Type", b'multipart/form-data; boundary=' + boundary + b'; charset=utf-8')
+				multipart = NetworkService.genReqStr(params)
+				reply = nam.post(req, multipart)
+				multipart.setParent(reply)
+				logger.debug("after reply setparent")
 			elif isinstance(params, bytes):
 				req.setRawHeader(b"Content-Type", b'application/x-www-form-urlencoded')
-				multipart = params
+				reply = nam.post(req, params)
+				logger.debug("after nam post")
 			else:
-				raise ValueError("cannot diffentiate headers to that param type")
-			# print(params)
-			# print(type(params))
-			return (
-				RequestWrapper(nam.post(req, multipart), successHandler, failureHandler, finishedHandler, parent,
-				               url=url,
-				               failSilent=failSilent))
+				raise ValueError("cannot differentiate headers to that param type")
+			logger.debug("params: %r", params)
+			logger.debug("reply: %r", reply)
+			return RequestWrapper(
+				reply,
+				successHandler,
+				failureHandler,
+				finishedHandler,
+				parent,
+				url=url,
+				failSilent=failSilent)
 		else:
-			return (RequestWrapper(nam.get(req), successHandler, failureHandler, finishedHandler, parent, url=url,
-			                       failSilent=failSilent))
+			return RequestWrapper(
+				nam.get(req),
+				successHandler,
+				failureHandler,
+				finishedHandler,
+				parent,
+				url=url,
+				failSilent=failSilent)
 
 	@staticmethod
 	def decode(req):
+		logger.debug("request.decode: %r", req)
 		data = req.readAll().data().decode("utf-8")
-		# NetworkService.logger.debug("decoding request data %r", data)
 		return json.loads(data)
 
 	@staticmethod
 	def setup(url, *args, **kwargs):
+		logger.debug("request.setup: %r, %r", args, kwargs)
 		NetworkService.url = url
 		# This is the only request that is intentionally blocking
 		try:
-			req = request.urlopen(url+"/getVersion")
+			req = request.urlopen(url + "/getVersion")
 			NetworkService.serverVersion = tuple(json.loads(req.read().decode("UTF-8")))
-			assert isinstance(NetworkService.serverVersion, tuple) and len(NetworkService.serverVersion)==3
+			assert isinstance(NetworkService.serverVersion, tuple) and len(NetworkService.serverVersion) == 3
 		except:
 			NetworkService.serverVersion = (1, 0, 0)  # The first version of ViUR didn't support that
 		logger.info("Attached to an instance running ViUR %s", NetworkService.serverVersion)
 		securityTokenProvider.reset()
-

--- a/viur_admin/protocolwrapper/file.py
+++ b/viur_admin/protocolwrapper/file.py
@@ -4,11 +4,14 @@
 import os
 import sys
 
+from collections import deque
+
+
 from PyQt5 import QtCore
 
 from viur_admin.config import conf
 from viur_admin.log import getLogger
-from viur_admin.network import NetworkService, RequestGroup, RequestWrapper
+from viur_admin.network import NetworkService
 from viur_admin.priorityqueue import protocolWrapperClassSelector
 from viur_admin.protocolwrapper.tree import TreeWrapper
 
@@ -37,7 +40,7 @@ ignorePatterns = [
 	# x_startswith_tilde,
 	lambda x: x.startswith("."),  # All files/dirs starting with a dot (".")
 	lambda x: x.lower() == "thumbs.db",  # Thumbs.DB,
-	lambda x: x.startswith("~") or x.endswith("~")  # Temp files (ususally starts/ends with ~)
+	lambda x: x.startswith("~") or x.endswith("~")  # Temp files (usually starts/ends with ~)
 ]
 
 
@@ -70,7 +73,9 @@ class FileUploader(QtCore.QObject):
 	def startUpload(self, req):
 		self.uploadProgress.emit(0, 1)
 		url = req.readAll().data().decode("UTF-8")
-		params = {"Filedata": open(self.fileName.encode(sys.getfilesystemencoding()), "rb")}
+		myFile = QtCore.QFile(self.fileName)
+		myFile.open(QtCore.QIODevice.ReadOnly)
+		params = {"Filedata": myFile}
 		if self.node:
 			params["node"] = self.node
 		req = NetworkService.request(url, params, finishedHandler=self.onFinished)
@@ -102,7 +107,8 @@ class FileUploader(QtCore.QObject):
 			"filesTotal": 1,
 			"filesDone": 1 if self.bytesDone == self.bytesTotal else 0,
 			"bytesTotal": self.bytesTotal,
-			"bytesDone": self.bytesDone}
+			"bytesDone": self.bytesDone
+		}
 		logger.debug("FileUploader.getStats: %r", stats)
 		return stats
 
@@ -111,12 +117,12 @@ class FileUploader(QtCore.QObject):
 
 
 class RecursiveUploader(QtCore.QObject):
-	"""
-		Upload files and/or directories from the the local filesystem to the server.
-		This one is recursive, it supports uploading of files in subdirectories as well.
-		Subdirectories on the server are created as needed.
-		The functionality is bound to a widget displaying the current progress.
-		If downloading has finished, finished(PyQt_PyObject=self) is emited.
+	"""Upload files and/or directories from the the local filesystem to the server.
+
+	This one is recursive, it supports uploading of files in subdirectories as well.
+	Subdirectories on the server are created as needed.
+	The functionality is bound to a widget displaying the current progress.
+	If downloading has finished, finished(PyQt_PyObject=self) is emited.
 	"""
 
 	directorySize = 15  # Let's count an directory as 15 Bytes
@@ -135,9 +141,9 @@ class RecursiveUploader(QtCore.QObject):
 		else:
 			return name
 
-	def __init__(self, files, node, module, *args, **kwargs):
+	def __init__(self, files, node, module, stats, *args, **kwargs):
 		"""
-			@param files: List of local files or directories (including thier absolute path) which will be uploaded.
+			@param files: List of local files or directories (including their absolute path) which will be uploaded.
 			@type files: list
 			@param node: Destination rootNode
 			@type node: str
@@ -147,11 +153,11 @@ class RecursiveUploader(QtCore.QObject):
 			@type module: str
 		"""
 		super(RecursiveUploader, self).__init__(*args, **kwargs)
-		print("RecursiveUploader", files, node)
+		logger.debug("RecursiveUploader.init: %r, %r, %r, %r, %r, %r", files, node, module, stats, args, kwargs)
 		self.node = node
 		self.module = module
 		self.hasFinished = False
-		self.taskQueue = []
+		self.taskQueue = deque()
 		self.runningTasks = 0
 		filteredFiles = [
 			x for x in files if
@@ -159,13 +165,19 @@ class RecursiveUploader(QtCore.QObject):
 		# self.recursionInfo = [ (  ) ] , [node], {}) ]
 		self.cancel.connect(self.onCanceled)
 		self.isCanceled = False
-		self.stats = {
-			"dirsTotal": 0,
-			"dirsDone": 0,
-			"filesTotal": 0,
-			"filesDone": 0,
-			"bytesTotal": 0,
-			"bytesDone": 0}
+		if stats:
+			self.stats = stats
+			logger.debug("initialsStats: %r, %r", stats["filesTotal"], stats["bytesTotal"])
+		else:
+			self.stats = {
+				"dirsTotal": 0,
+				"dirsDone": 0,
+				"filesTotal": 0,
+				"filesDone": 0,
+				"bytesTotal": 0,
+				"bytesDone": 0
+			}
+
 		for fileName in filteredFiles:
 			name, fname = os.path.split(fileName)
 			if not fname:
@@ -174,18 +186,18 @@ class RecursiveUploader(QtCore.QObject):
 				# We can ignore that file
 				continue
 			if os.path.isdir(fileName.encode(sys.getfilesystemencoding())):
-				task = {"type":"netreq",
-				        "args" : ["/%s/list/node/%s" % (self.module, self.node),],
-				        "kwargs": {"successHandler": self.onDirListAvailable},
-				        "uploadDirName": fileName}
+				task = {
+					"type": "netreq",
+					"args": ["/{0}/list/node/{1}".format(self.module, self.node)],
+					"kwargs": {"successHandler": self.onDirListAvailable},
+					"uploadDirName": fileName}
 				self.taskQueue.append(task)
-				self.stats["dirsTotal"] += 1
 			else:
-				task = {"type": "upload",
-				        "args": [fileName, self.node,],
-				        "kwargs": {"parent": self}}
+				task = {
+					"type": "upload",
+					"args": [fileName, self.node],
+					"kwargs": {"parent": self}}
 				self.taskQueue.append(task)
-				self.stats["filesTotal"] += 1
 		logger.debug("RecursiveUploader.init: %r", self.stats)
 		# self.uploadProgress.emit(0, 0)
 		self.launchNextRequest()
@@ -197,7 +209,7 @@ class RecursiveUploader(QtCore.QObject):
 		if self.runningTasks > 1:
 			return
 		self.runningTasks += 1
-		task = self.taskQueue.pop(0)
+		task = self.taskQueue.popleft()
 		if task["type"] == "netreq":
 			r = NetworkService.request(*task["args"], **task["kwargs"])
 			r.uploadDirName = task["uploadDirName"]
@@ -219,18 +231,12 @@ class RecursiveUploader(QtCore.QObject):
 		self.launchNextRequest()
 
 	def timerEvent(self, e):
+		"""Check if we have busy tasks left
 		"""
-			Check if we have busy tasks left
-		"""
+
 		super(RecursiveUploader, self).timerEvent(e)
 		busy = self.runningTasks > 0
-		#for child in self.children():
-		#	if isinstance(child, RequestWrapper) or isinstance(child, RequestGroup) or isinstance(child,
-		#	                                                                                      FileUploader) or isinstance(
-		#			child, RecursiveUploader):
-		#		if not child.hasFinished:
-		#			busy = True
-		#			break
+
 		if not busy:
 			self.hasFinished = True
 			self.finished.emit(self)
@@ -243,26 +249,33 @@ class RecursiveUploader(QtCore.QObject):
 			"filesTotal": 0,
 			"filesDone": 0,
 			"bytesTotal": 0,
-			"bytesDone": 0}
+			"bytesDone": 0
+		}
+
 		# Merge my stats in
 		for k in stats.keys():
-			stats[k] += self.stats[k]
+			try:
+				stats[k] += self.stats[k]
+			except KeyError:
+				pass
 		for child in self.children():
 			try:
 				tmp = child.getStats()
 				for k in stats.keys():
-					if isinstance(child, FileUploader) and k=="filesTotal":
+					if isinstance(child, FileUploader) and k == "filesTotal":
 						# We count files in advance; don't include FileUpload-Class while counting
 						continue
 					try:
 						stats[k] += tmp[k]
+					except KeyError as err:
+						pass
 					except TypeError as err:
 						logger.error(
 							"RecursiveUploader.getStats - error occurred while collecting stats from child: %r, %r, %r, %r",
 							stats, tmp, child, k)
-						#logger.exception(err)
+			# logger.exception(err)
 			except AttributeError as err:
-				#logger.exception(err)
+				# logger.exception(err)
 				pass
 		logger.debug("RecursiveUploader.getStats: %r", stats)
 		return stats
@@ -275,23 +288,29 @@ class RecursiveUploader(QtCore.QObject):
 		data = NetworkService.decode(req)
 		for skel in data["skellist"]:
 			if skel["name"].lower() == self.getDirName(req.uploadDirName).lower():
-				logger.debug("onDirListAvailable dir: %r", skel["name"])
-				# This directory allready exists
+				logger.debug("onDirListAvailable: directory %r already exists", skel["name"])
 				self.stats["dirsDone"] += 1
 
-				task = {"type": "rekul",
-				        "args": [[os.path.join(req.uploadDirName, x) for x in os.listdir(req.uploadDirName)],
-				                      skel["key"], self.module],
-				        "kwargs": {"parent": self}}
+				task = {
+					"type": "rekul",
+					"args": [
+						[os.path.join(req.uploadDirName, x) for x in os.listdir(req.uploadDirName)],
+						skel["key"],
+						self.module,
+						None
+					],
+					"kwargs": {"parent": self}}
 				self.taskQueue.append(task)
 		else:
-			task = {"type": "netreq",
-			        "args": ["/%s/add/" % self.module, {"node": self.node, "name": self.getDirName(req.uploadDirName), "skelType": "node"}],
-			        "kwargs": {"secure": True, "finishedHandler": self.onMkDir},
-			        "uploadDirName": req.uploadDirName}
+			task = {
+				"type": "netreq",
+				"args": [
+					"/%s/add/" % self.module,
+					{"node": self.node, "name": self.getDirName(req.uploadDirName), "skelType": "node"}],
+				"kwargs": {"secure": True, "finishedHandler": self.onMkDir},
+				"uploadDirName": req.uploadDirName}
 			self.taskQueue.append(task)
 		self.launchNextRequest()
-		self.uploadProgress.emit(0, 1)
 
 	def onMkDir(self, req):
 		if self.isCanceled:
@@ -299,20 +318,19 @@ class RecursiveUploader(QtCore.QObject):
 		data = NetworkService.decode(req)
 		assert data["action"] == "addSuccess"
 		self.stats["dirsDone"] += 1
+		self.stats["bytesDone"] += self.directorySize
 		self.runningTasks -= 1
 
-		task = {"type": "rekul",
-		        "args": [[os.path.join(req.uploadDirName, x) for x in os.listdir(req.uploadDirName)],
-		                      data["values"]["key"], self.module],
-		        "kwargs": {"parent": self}}
+		task = {
+			"type": "rekul",
+			"args": [
+				[os.path.join(req.uploadDirName, x) for x in os.listdir(req.uploadDirName)],
+				data["values"]["key"], self.module,
+				None
+			],
+			"kwargs": {"parent": self}}
 		self.taskQueue.append(task)
-
-		#r = RecursiveUploader([os.path.join(req.uploadDirName, x) for x in os.listdir(req.uploadDirName)],
-		#                      data["values"]["key"], self.module, parent=self)
-		#r.uploadProgress.connect(self.uploadProgress)
-		#self.cancel.connect(r.cancel)
 		self.launchNextRequest()
-		self.uploadProgress.emit(0, 1)
 
 	def onCanceled(self, *args, **kwargs):
 		self.isCanceled = True
@@ -369,8 +387,8 @@ class RecursiveDownloader(QtCore.QObject):
 			self.remainingRequests += 1
 			dlkey = "/%s/download/%s/file.dat" % (self.modul, file["dlkey"])
 			request = NetworkService.request(
-					dlkey, successHandler=self.saveFile,
-					finishedHandler=self.onRequestFinished)
+				dlkey, successHandler=self.saveFile,
+				finishedHandler=self.onRequestFinished)
 			request.fname = file["name"]
 			request.fsize = file["size"]
 			request.downloadProgress.connect(self.onDownloadProgress)
@@ -378,14 +396,18 @@ class RecursiveDownloader(QtCore.QObject):
 			self.stats["bytesTotal"] += file["size"]
 		for directory in dirs:
 			assert "~" not in directory["name"] and ".." not in directory["name"]
-			for t in ["node", "leaf"]:
+			for nodeType in ["node", "leaf"]:
 				self.remainingRequests += 1
 				if not os.path.exists(os.path.join(self.localTargetDir, directory["name"])):
 					os.mkdir(os.path.join(self.localTargetDir, directory["name"]))
-				request = NetworkService.request("/%s/list/%s/%s" % (self.modul, t, directory["key"]),
-				                                 successHandler=self.onListDir, finishedHandler=self.onRequestFinished)
+
+				request = NetworkService.request(
+					"/{0}/list/{1}/{2}".format(self.modul, nodeType, directory["key"]),
+					successHandler=self.onListDir,
+					finishedHandler=self.onRequestFinished)
+
 				request.dname = directory["name"]
-				request.ntype = t
+				request.ntype = nodeType
 			self.stats["dirsTotal"] += 1
 			self.stats["bytesTotal"] += self.directorySize
 
@@ -418,11 +440,11 @@ class RecursiveDownloader(QtCore.QObject):
 		if req.ntype == "node":
 			self.remainingRequests += 1
 			r = RecursiveDownloader(
-					os.path.join(self.localTargetDir, req.dname),
-					[],
-					data["skellist"],
-					self.modul,
-					parent=self)
+				os.path.join(self.localTargetDir, req.dname),
+				[],
+				data["skellist"],
+				self.modul,
+				parent=self)
 			r.downloadProgress.connect(self.downloadProgress)
 			r.finished.connect(self.onRequestFinished)
 		else:
@@ -430,11 +452,11 @@ class RecursiveDownloader(QtCore.QObject):
 			self.stats["dirsDone"] += 1
 			self.stats["bytesDone"] += self.directorySize
 			r = RecursiveDownloader(
-					os.path.join(self.localTargetDir, req.dname),
-					data["skellist"],
-					[],
-					self.modul,
-					parent=self)
+				os.path.join(self.localTargetDir, req.dname),
+				data["skellist"],
+				[],
+				self.modul,
+				parent=self)
 			r.downloadProgress.connect(self.downloadProgress)
 			r.finished.connect(self.onRequestFinished)
 
@@ -464,6 +486,37 @@ class FileWrapper(TreeWrapper):
 		super(FileWrapper, self).__init__(*args, **kwargs)
 		self.transferQueues = []  # Keep a reference to uploader/downloader
 
+	def buildStats(self, filteredFiles):
+		stats = {
+			"dirsTotal": 0,
+			"dirsDone": 0,
+			"filesTotal": 0,
+			"filesDone": 0,
+			"bytesTotal": 0,
+			"bytesDone": 0
+		}
+
+		for myPath in filteredFiles:
+			if os.path.isdir(myPath.encode(sys.getfilesystemencoding())):
+				stats["dirsTotal"] += 1  # for the root
+
+				for root, directories, files in os.walk(myPath):
+					encodedRoot = root.encode(sys.getfilesystemencoding())
+					for item in files:
+						encodedItem = item.encode(sys.getfilesystemencoding())
+						print(repr(encodedRoot), repr(encodedItem))
+						stats["bytesTotal"] += os.path.getsize(os.path.join(encodedRoot, encodedItem))
+					stats["filesTotal"] += len(files)
+					lenDirectories = len(directories)
+					stats["dirsTotal"] += lenDirectories
+					stats["bytesTotal"] += 15 * lenDirectories
+			else:
+				stats["filesTotal"] += 1
+				stats["bytesTotal"] += os.path.getsize(myPath.encode(sys.getfilesystemencoding()))
+
+		logger.debug("buildStats finished: %r, %r", stats["filesTotal"], stats["bytesTotal"])
+		return stats
+
 	def upload(self, files, node):
 		"""
 			Uploads a list of files to the Server and adds them to the given path on the server.
@@ -474,8 +527,14 @@ class FileWrapper(TreeWrapper):
 		"""
 		if not files:
 			return
-		uploader = RecursiveUploader(files, node, self.module, parent=self)
+
+		filteredFiles = [
+			x for x in files if
+			conf.cmdLineOpts.noignore or not any([pattern(x) for pattern in ignorePatterns])]
+		stats = self.buildStats(filteredFiles)
+		uploader = RecursiveUploader(filteredFiles, node, self.module, stats, parent=self)
 		uploader.finished.connect(self.delayEmitEntriesChanged)
+		logger.debug("Filewrapper.upload: %r, %r, %r", files, node, uploader)
 		return uploader
 
 	def download(self, targetDir, files, dirs):

--- a/viur_admin/protocolwrapper/tree.py
+++ b/viur_admin/protocolwrapper/tree.py
@@ -330,6 +330,7 @@ class TreeWrapper(QtCore.QObject):
 				self._requestGroups.remove(req)
 				logger.debug("request group removed")
 			except Exception as err:
+				logger.exception(err)
 				logger.error("request group could not be removed")
 				pass
 		QtCore.QTimer.singleShot(self.updateDelay, self.emitEntriesChanged)

--- a/viur_admin/widgets/file.py
+++ b/viur_admin/widgets/file.py
@@ -43,7 +43,7 @@ class PreviewThread(QtCore.QThread):
 				wasDownloaded = False
 				if not os.path.isfile(fileName):
 					wasDownloaded = True
-					req = urllib.request.Request("{0}{1]{2}".format(NetworkService.url.replace("/admin", ""), "/file/download/", dlKey))
+					req = urllib.request.Request("{0}{1}{2}".format(NetworkService.url.replace("/admin", ""), "/file/download/", dlKey))
 					try:
 						response = urllib.request.urlopen(req)
 					except:

--- a/viur_admin/widgets/file.py
+++ b/viur_admin/widgets/file.py
@@ -1,19 +1,21 @@
 # -*- coding: utf-8 -*-
 
+import os
+import urllib.request
+from hashlib import sha1
+
 from PyQt5 import QtCore, QtGui, QtWidgets
 
+from viur_admin.config import conf
 from viur_admin.log import getLogger
-from viur_admin.network import RemoteFile, NetworkService
+from viur_admin.network import NetworkService
 from viur_admin.priorityqueue import protocolWrapperInstanceSelector
 from viur_admin.ui.fileDownloadProgressUI import Ui_FileDownloadProgress
 from viur_admin.ui.fileUploadProgressUI import Ui_FileUploadProgress
 from viur_admin.widgets.tree import TreeWidget, LeafItem, TreeListView
-import urllib.request
-from viur_admin.config import conf
-import os
-from hashlib import sha1
 
 logger = getLogger(__name__)
+
 
 class PreviewThread(QtCore.QThread):
 	requestPreviewImage = QtCore.pyqtSignal((str))
@@ -28,7 +30,8 @@ class PreviewThread(QtCore.QThread):
 		self.start(QtCore.QThread.IdlePriority)
 		while self.threadThread is None:
 			self.usleep(5)
-		#self.moveToThread(self.threadThread)
+
+	# self.moveToThread(self.threadThread)
 
 	def run(self):
 		self.threadThread = self.currentThread()
@@ -40,7 +43,7 @@ class PreviewThread(QtCore.QThread):
 				wasDownloaded = False
 				if not os.path.isfile(fileName):
 					wasDownloaded = True
-					req = urllib.request.Request(NetworkService.url.replace("/admin","")+"/file/download/"+dlKey)
+					req = urllib.request.Request("{0}{1]{2}".format(NetworkService.url.replace("/admin", ""), "/file/download/", dlKey))
 					try:
 						response = urllib.request.urlopen(req)
 					except:
@@ -58,7 +61,7 @@ class PreviewThread(QtCore.QThread):
 						# Store the file sothat it won't be downloaded again next time
 						open(fileName, "wb+").write(fileData)
 				self.msleep(25)
-				#self.sleep(1)
+			# self.sleep(1)
 			except IndexError:
 				self.sleep(1)
 
@@ -69,8 +72,8 @@ class PreviewThread(QtCore.QThread):
 	def requestPreview(self, dlkey):
 		self.requestPreviewImage.emit(dlkey)
 
-previewer = PreviewThread()
 
+previewer = PreviewThread()
 
 
 class FileItem(LeafItem):
@@ -93,7 +96,7 @@ class FileItem(LeafItem):
 			icon = QtGui.QIcon(":icons/filetypes/unknown.png")
 		self.setIcon(icon)
 		if ("metamime" in data.keys() and str(data["metamime"]).lower().startswith("image")) or (
-							extension in ["jpg", "jpeg", "png"] and "servingurl" in data.keys() and data["servingurl"]):
+				extension in ["jpg", "jpeg", "png"] and "servingurl" in data.keys() and data["servingurl"]):
 			previewer.previewImageAvailable.connect(self.onPreviewImageAvailable)
 			previewer.requestPreview(data["dlkey"])
 		self.setText(self.entryData["name"])
@@ -125,49 +128,53 @@ class UploadStatusWidget(QtWidgets.QWidget):
 		If downloading has finished, finished(PyQt_PyObject=self) is emited.
 	"""
 
-	directorySize = 15  # Let's count an directory as 15 Bytes
+	def __init__(self, *args, **kwargs):
+		"""Copy paste error
 
-	def __init__(self, uploader, *args, **kwargs):
+		TODO: fix the docs
+
+		@param files: List of local files or directories (including thier absolute path) which will be uploaded.
+		@type files: List
+		@param rootNode: Destination rootNode
+		@type rootNode: String
+		@param path: Remote destination path, relative to rootNode.
+		@type path: String
+		@param modul: Modulname to upload to (usually "file")
+		@type modul: String
 		"""
-			@param files: List of local files or directories (including thier absolute path) which will be uploaded.
-			@type files: List
-			@param rootNode: Destination rootNode
-			@type rootNode: String
-			@param path: Remote destination path, relative to rootNode.
-			@type path: String
-			@param modul: Modulname to upload to (usually "file")
-			@type modul: String
-		"""
+
 		super(UploadStatusWidget, self).__init__(*args, **kwargs)
 		self.ui = Ui_FileUploadProgress()
 		self.ui.setupUi(self)
+		logger.debug("UploadStatusWidget.init: %r, %r", args, kwargs)
+
+	def setUploader(self, uploader):
 		self.uploader = uploader
 		self.uploader.uploadProgress.connect(self.onUploadProgress)
 		self.uploader.finished.connect(self.onFinished)
+		self.ui.pbarTotal.setRange(0, uploader.stats["filesTotal"])
 
 	def onBtnCancelReleased(self, *args, **kwargs):
 		self.uploader.cancelUpload()
 
-	def onUploadProgress(self, bytesSend, bytesTotal):
-		"""Updates the process widget
-
-		:param bytesSend:
-		:type bytesSend: int
-		:param bytesTotal:
-		:type bytesTotal: int
-		:return:
-		"""
-
+	def onUploadProgress(self, currentFileDone, currentFileTotal):
 		stats = self.uploader.getStats()
-		logger.debug("UploadStatusWidget.onUploadProgress: %r, %r, %r", bytesSend, bytesTotal, stats)
+		logger.debug("UploadStatusWidget.onUploadProgress: %r", stats)
 		self.ui.lblProgress.setText(
-			QtCore.QCoreApplication.translate("FileHandler", "Files: %s/%s, Directories: %s/%s, Bytes: %s/%s") % (
-				stats["filesDone"], stats["filesTotal"], stats["dirsDone"], stats["dirsTotal"], stats["bytesDone"],
-				stats["bytesTotal"]))
-		self.ui.pbarTotal.setRange(0, stats["filesTotal"])
+			QtCore.QCoreApplication.translate(
+				"FileHandler",
+				"Files: %s/%s, Directories: %s/%s, Bytes: %s/%s") % (
+				stats["filesDone"],
+				stats["filesTotal"],
+				stats["dirsDone"],
+				stats["dirsTotal"],
+				stats["bytesDone"],
+				stats["bytesTotal"])
+		)
+
+		self.ui.pbarFile.setRange(0, currentFileTotal)
+		self.ui.pbarFile.setValue(currentFileDone)
 		self.ui.pbarTotal.setValue(stats["filesDone"])
-		self.ui.pbarFile.setRange(0, stats["bytesTotal"])
-		self.ui.pbarFile.setValue(stats["bytesDone"])
 
 	def askOverwriteFile(self, title, text):
 		res = QtWidgets.QMessageBox.question(self, title, text,
@@ -207,6 +214,7 @@ class DownloadStatusWidget(QtWidgets.QWidget):
 			@param modul: Modulname to download from (usually "file")
 			@type modul: String
 		"""
+		logger.debug("DownloadStatusWidget.init: %r, %r, %r", downloader, args, kwargs)
 		super(DownloadStatusWidget, self).__init__(*args, **kwargs)
 		self.ui = Ui_FileDownloadProgress()
 		self.ui.setupUi(self)
@@ -251,9 +259,11 @@ class FileListView(TreeListView):
 		"""
 		if not files:
 			return
+		uploadStatusWidget = UploadStatusWidget()
+		self.parent().layout().addWidget(uploadStatusWidget)
 		protoWrap = protocolWrapperInstanceSelector.select(self.getModul())
 		uploader = protoWrap.upload(files, node)
-		self.parent().layout().addWidget(UploadStatusWidget(uploader))
+		uploadStatusWidget.setUploader(uploader)
 
 	def doDownload(self, targetDir, files, dirs):
 		"""
@@ -273,7 +283,7 @@ class FileListView(TreeListView):
 		"""Allow Drag&Drop'ing from the local filesystem into our fileview
 		"""
 		if (all([str(file.toLocalFile()).startswith("file://") or str(file.toLocalFile()).startswith("/") or (
-						len(str(file.toLocalFile())) > 0 and str(file.toLocalFile())[1] == ":") for file in
+				len(str(file.toLocalFile())) > 0 and str(file.toLocalFile())[1] == ":") for file in
 		         event.mimeData().urls()])) and len(event.mimeData().urls()) > 0:
 			# Its an upload (files/dirs dragged from the local filesystem into our fileview)
 			self.doUpload([file.toLocalFile() for file in event.mimeData().urls()], self.getNode())
@@ -285,8 +295,8 @@ class FileListView(TreeListView):
 		(drag directorys out isnt currently supported)
 		"""
 		if (all([file.toLocalFile() and (
-						str(file.toLocalFile()).startswith("file://") or str(file.toLocalFile()).startswith("/") or
-						str(file.toLocalFile())[1] == ":") for file in event.mimeData().urls()])) and len(
+				str(file.toLocalFile()).startswith("file://") or str(file.toLocalFile()).startswith("/") or
+				str(file.toLocalFile())[1] == ":") for file in event.mimeData().urls()])) and len(
 			event.mimeData().urls()) > 0:
 			event.accept()
 		else:


### PR DESCRIPTION
This commit starts a series of improving changes to the handling of general networking and especially file uploads

* switched from manually building up requests to qt provided classes to handle form and multipart requests
* now we are able to upload really big files without out of memory errors
* polished a lot of code path and string concats
* keeping the old generateRequestStr method for reference until all code branches are hit and ok
* we still have to figure out, if we want to provide a mixed selection of directories and files in upload - this seems to be not as easy as I've guessed before. In actions/file please take a look on the TODOs